### PR TITLE
HomeFragment 탭 변경 시 버그 수정 및 일부 코드 리팩토링

### DIFF
--- a/app/src/main/java/com/example/my_media/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/my_media/home/HomeFragment.kt
@@ -1,12 +1,11 @@
 package com.example.my_media.home
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import com.example.my_media.R
@@ -14,7 +13,6 @@ import com.example.my_media.databinding.FragmentHomeBinding
 import com.example.my_media.detail.VideoDetailFragment
 import com.example.my_media.home.popular.HomePopularListAdapter
 import com.example.my_media.home.subscribe.HomeSubscribeListAdapter
-import com.example.my_media.search.SearchFragment
 import com.example.my_media.util.UserManager
 
 class HomeFragment : Fragment() {
@@ -25,8 +23,9 @@ class HomeFragment : Fragment() {
     private var _binding: FragmentHomeBinding? = null
     private val binding get() = _binding!!
 
+    private var videoCategoryId: String? = null
 
-    private val viewModel: HomeViewModel by viewModels() {
+    private val viewModel: HomeViewModel by activityViewModels() {
         HomeViewModelFactory()
     }
 
@@ -73,9 +72,6 @@ class HomeFragment : Fragment() {
         }
 
         val accessToken = UserManager.getAccessToken()
-        viewModel.getSubscribeList("Bearer $accessToken") //구독 리스트 불러오기
-
-        viewModel.getPopularVideo("Bearer $accessToken", "0")
 
         val chips = listOf(
             R.id.chip_all to "0",
@@ -85,16 +81,16 @@ class HomeFragment : Fragment() {
             R.id.chip_comedy to "23"
         )
 
-        var videoCategoryId = ""
-        chipGroup.setOnCheckedChangeListener { group, checkedId ->
-            for (i in chips.indices) {
-                if (checkedId == chips.get(i).first) {
-                    videoCategoryId = chips.get(i).second
-                    Log.d("sooj", "chips click ${videoCategoryId}")
-                }
+        viewModel.getSubscribeList("Bearer $accessToken") //구독 리스트 불러오기
+        if(videoCategoryId.isNullOrBlank()) {
+            viewModel.getPopularVideo("Bearer $accessToken","0") //인기 동영상 불러오기
+        }
+
+        chipGroup.setOnCheckedChangeListener { _, checkedId ->
+            if(checkedId != -1) {
+                videoCategoryId = chips.find { it.first == checkedId }?.second
+                viewModel.getPopularVideo("Bearer $accessToken", videoCategoryId ?: "0")
             }
-            viewModel.getPopularVideo("Bearer $accessToken", videoCategoryId)
-            Log.d("sooj", " test : $videoCategoryId ")
         }
     }
 

--- a/app/src/main/java/com/example/my_media/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/my_media/home/HomeFragment.kt
@@ -14,16 +14,12 @@ import com.example.my_media.databinding.FragmentHomeBinding
 import com.example.my_media.detail.VideoDetailFragment
 import com.example.my_media.home.popular.HomePopularListAdapter
 import com.example.my_media.home.subscribe.HomeSubscribeListAdapter
+import com.example.my_media.search.SearchFragment
+import com.example.my_media.util.UserManager
 
 class HomeFragment : Fragment() {
     companion object {
-        fun newInstance(accessToken: String): HomeFragment {
-            val args = Bundle()
-            args.putString("AccessToken", accessToken)
-            val fragment = HomeFragment()
-            fragment.arguments = args
-            return fragment
-        }
+        fun newInstance() = HomeFragment()
     }
 
     private var _binding: FragmentHomeBinding? = null
@@ -76,7 +72,7 @@ class HomeFragment : Fragment() {
             adapter = homePopularListAdapter
         }
 
-        val accessToken = arguments?.getString("AccessToken") ?: ""
+        val accessToken = UserManager.getAccessToken()
         viewModel.getSubscribeList("Bearer $accessToken") //구독 리스트 불러오기
 
         viewModel.getPopularVideo("Bearer $accessToken", "0")

--- a/app/src/main/java/com/example/my_media/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/my_media/home/HomeViewModel.kt
@@ -51,23 +51,26 @@ class HomeViewModel(private val youtubeRepositoryImpl: YoutubeRepositoryImpl) : 
 
     fun getPopularVideo(accessToken: String, videoCategoryId : String) { //카테고리 아이디를 파라미터로 받기
         viewModelScope.launch {
-            val response = youtubeRepositoryImpl.getPopularVideo(accessToken, videoCategoryId).items // 모든 데이터
-            val popularVideoItems = ArrayList<HomePopularModel>()
-            response.forEach {
-                popularVideoItems.add(
-                    HomePopularModel(
-                        txtTitle = it.popularSnippet?.title.orEmpty(),
-                        txtDescription = it.popularSnippet?.description.orEmpty(),
-                        imgThumbnail = it.popularSnippet?.popularThumbnails?.standard?.url.orEmpty(),
-                        isLiked = false,
-                        viewCount = it.statistics?.viewCount,
-                        likeCount = it.statistics?.likeCount,
-                        commentCount = it.statistics?.commentCount
-
+            runCatching {
+                val response = youtubeRepositoryImpl.getPopularVideo(accessToken, videoCategoryId).items // 모든 데이터
+                val popularVideoItems = ArrayList<HomePopularModel>()
+                response.forEach {
+                    popularVideoItems.add(
+                        HomePopularModel(
+                            txtTitle = it.popularSnippet?.title.orEmpty(),
+                            txtDescription = it.popularSnippet?.description.orEmpty(),
+                            imgThumbnail = it.popularSnippet?.popularThumbnails?.standard?.url.orEmpty(),
+                            isLiked = false,
+                            viewCount = it.statistics?.viewCount,
+                            likeCount = it.statistics?.likeCount,
+                            commentCount = it.statistics?.commentCount
+                        )
                     )
-                )
-            }// 일부 값 추출
-            _popularVideoList.value = popularVideoItems // 호출
+                }
+                _popularVideoList.postValue(popularVideoItems)
+            }.onFailure {
+                Log.e("Network Failed", it.message.toString())
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/my_media/main/MainActivity.kt
+++ b/app/src/main/java/com/example/my_media/main/MainActivity.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.fragment.app.Fragment
 import com.example.my_media.R
 import com.example.my_media.databinding.ActivityMainBinding
 import com.example.my_media.home.HomeFragment
@@ -26,6 +27,18 @@ class MainActivity : AppCompatActivity() {
 
     private val viewModel: MainViewModel by viewModels {
         MainViewModelFactory(applicationContext as Application)
+    }
+
+    private val homeFragment by lazy {
+        HomeFragment.newInstance()
+    }
+
+    private val searchFragment by lazy {
+        SearchFragment.newInstance()
+    }
+
+    private val myVideoFragment by lazy {
+        MyVideoFragment.newInstance()
     }
 
     private val googleAuthLauncher =
@@ -77,18 +90,20 @@ class MainActivity : AppCompatActivity() {
             Toast.LENGTH_SHORT
         )
 
-        supportFragmentManager.beginTransaction().add(R.id.frameLayout, HomeFragment.newInstance()).commit()
+        supportFragmentManager.beginTransaction().add(R.id.frameLayout, homeFragment).commit()
 
         bottomNavigationView.setOnItemSelectedListener { item ->
-            when (item.itemId) {
-                R.id.menu_home -> supportFragmentManager.beginTransaction()
-                    .replace(R.id.frameLayout, HomeFragment.newInstance()).commit()
-
-                R.id.menu_search -> supportFragmentManager.beginTransaction()
-                    .replace(R.id.frameLayout, SearchFragment.newInstance()).commit()
-
-                R.id.menu_my_video -> supportFragmentManager.beginTransaction()
-                    .replace(R.id.frameLayout, MyVideoFragment.newInstance()).commit()
+            val selectedFragment = when (item.itemId) {
+                R.id.menu_home -> homeFragment
+                R.id.menu_search -> searchFragment
+                R.id.menu_my_video -> myVideoFragment
+                else -> null
+            }
+            if (selectedFragment != null) {
+                if (!selectedFragment.isAdded) {
+                    supportFragmentManager.beginTransaction()
+                        .replace(R.id.frameLayout, selectedFragment).commit()
+                }
             }
             true
         }

--- a/app/src/main/java/com/example/my_media/main/MainActivity.kt
+++ b/app/src/main/java/com/example/my_media/main/MainActivity.kt
@@ -13,6 +13,7 @@ import com.example.my_media.databinding.ActivityMainBinding
 import com.example.my_media.home.HomeFragment
 import com.example.my_media.mypage.MyVideoFragment
 import com.example.my_media.search.SearchFragment
+import com.example.my_media.util.UserManager
 import com.example.my_media.util.showToast
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -54,7 +55,8 @@ class MainActivity : AppCompatActivity() {
 
     private fun initViewModel() = with(viewModel) {
         tokenData.observe(this@MainActivity) { token ->
-            initView(token)
+            UserManager.setAccessToken(token)
+            initView()
         }
     }
 
@@ -69,19 +71,18 @@ class MainActivity : AppCompatActivity() {
         googleAuthLauncher.launch(googleSignInClient.signInIntent)
     }
 
-    private fun initView(accessToken: String) = with(binding) {
+    private fun initView() = with(binding) {
         this@MainActivity.showToast(
             getString(R.string.main_toast_success_login),
             Toast.LENGTH_SHORT
         )
 
-        val homeFragment = HomeFragment.newInstance(accessToken)
-        supportFragmentManager.beginTransaction().add(R.id.frameLayout, homeFragment).commit()
+        supportFragmentManager.beginTransaction().add(R.id.frameLayout, HomeFragment.newInstance()).commit()
 
         bottomNavigationView.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.menu_home -> supportFragmentManager.beginTransaction()
-                    .replace(R.id.frameLayout, homeFragment).commit()
+                    .replace(R.id.frameLayout, HomeFragment.newInstance()).commit()
 
                 R.id.menu_search -> supportFragmentManager.beginTransaction()
                     .replace(R.id.frameLayout, SearchFragment.newInstance()).commit()

--- a/app/src/main/java/com/example/my_media/util/UserManager.kt
+++ b/app/src/main/java/com/example/my_media/util/UserManager.kt
@@ -1,0 +1,13 @@
+package com.example.my_media.util
+
+object UserManager {
+    private var accessToken: String? = null
+
+    fun setAccessToken(token: String) {
+        accessToken = token
+    }
+
+    fun getAccessToken(): String? {
+        return accessToken
+    }
+}


### PR DESCRIPTION
1. 사용자 정보(토큰 값) 싱글톤으로 분리하여 관리 (UserManager)
2. BottomNavigationView 선택 시 사용되는 Fragment Instance > by lazy 로 분리
3. 현재 선택되어있는 탭과 동일한 탭이 재 선택되는 경우, attach 여부 확인하여 방지하는 코드 추가
4. 다른 Fragment에서 다시 HomeFragment로 돌아온 다음 chip button 클릭 했을 때 앱 종료되는 이슈 해결

close #47 